### PR TITLE
翻訳の改善

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -644,7 +644,7 @@ int *dmg_p; /* for dishing out extra damage in lieu of Int loss */
             Sprintf(killer.name, "unwisely ate the brain of %s", pd->mname);
             killer.format = NO_KILLER_PREFIX;
 #else
-            Sprintf(killer.name, "‹ð‚©‚É‚à%s‚Ì‘Ì‚ðH‚×‚Ä", pd->mname);
+            Sprintf(killer.name, "‹ð‚©‚É‚à%s‚Ì”]‚ðH‚×‚Ä", pd->mname);
             killer.format = KILLED_BY;
 #endif
             done(DIED);


### PR DESCRIPTION
原文が "unwisely ate the brain of %s" となっており、「体」ではなく「脳」としたほうが妥当だと思いました。
なお、851行目では "unwisely ate the body of %s" が "愚かにも%sの体を食べて" と訳されています。