### PR TITLE
メインリポジトリURLの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ JNetHack 3.4.* から変更された主な点は以下の通りです。
 
 JNetHack では二つのレポジトリを使っています。
 
-### メインレポジトリ https://osdn.net/projects/jnethack/scm/git/source/
+### メインレポジトリ https://github.com/jnethack/jnethack-release
 
 ある程度確認したソースコードが登録されます。原則としてrebaseはしません。
 

--- a/src/eat.c
+++ b/src/eat.c
@@ -644,7 +644,7 @@ int *dmg_p; /* for dishing out extra damage in lieu of Int loss */
             Sprintf(killer.name, "unwisely ate the brain of %s", pd->mname);
             killer.format = NO_KILLER_PREFIX;
 #else
-            Sprintf(killer.name, "‹ð‚©‚É‚à%s‚Ì‘Ì‚ðH‚×‚Ä", pd->mname);
+            Sprintf(killer.name, "‹ð‚©‚É‚à%s‚Ì”]‚ðH‚×‚Ä", pd->mname);
             killer.format = KILLED_BY;
 #endif
             done(DIED);

--- a/src/eat.c
+++ b/src/eat.c
@@ -868,7 +868,7 @@ register int pm;
 /*JP
             You("don't feel very well.");
 */
-            You("すごく気分が悪い．");
+            You("あまり気分がよくない．");
             make_slimed(10L, (char *) 0);
             delayed_killer(SLIMED, KILLED_BY_AN, "");
         }


### PR DESCRIPTION
メインリポジトリのURLがOSDNのままになっていましたが、現在アクセス不可であるため修正しました。