### PR TITLE
Linux/FreeBSD/NetBSD 上で X11 抜きでビルドすると windowtype:curses で日本語が表示されない

### DIFF
--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -16,8 +16,10 @@
 #include <fcntl.h>
 #endif
 
-#ifdef XI18N
+#if defined(XI18N)
 #include <X11/Xlocale.h>
+#elif defined(CURSES_GRAPHICS)
+#include <locale.h>
 #endif
 
 #if !defined(_BULL_SOURCE) && !defined(__sgi) && !defined(_M_UNIX)
@@ -68,7 +70,7 @@ char *argv[];
     setkcode('U');
 #endif
 
-#ifdef XI18N
+#if defined(XI18N) || defined(CURSES_GRAPHICS)
     /* ƒtƒHƒ“ƒgİ’è‚Ì‚½‚ß‚ÉLC_ALL•Ï”‚ğŒÅ’è‚·‚é */
     putenv("LC_ALL=ja_JP.eucJP");
     setlocale(LC_ALL, "");


### PR DESCRIPTION
Linux 上で X11 抜き、正確には -DXI18N 抜きでビルドすると、
curses インターフェースで jnethack を実行した時に、メッセージの日本語部分が
空白で表示されてしまいます。この時 tty インターフェースでは問題なく動作します。

ヒントファイルで言うと、sys/unix/hints/linux でビルドすると再現します。
Debian でテストした際は、ファイルを修正して -lncurses ではなく -lncursesw で
ビルドしました。Debian 12.10 の場合、二者は別物なので。

(-lncurses でも、X11 インターフェース以外は割と動いてしまいますが、別の問題が出ます。)

(ちなみに FreeBSD や NetBSD だと、
  FreeBSD: libncurses は libncursesw へのシンボリックリンク
  NetBSD : libncurses の実体は libncursesw (--enable-widec --disable-lib-suffixes)
なので、-lncurses でもリンクされるのは ncursesw です。)

 # How to repeat

以下は Debian 12.10 の場合です。FreeBSD や NetBSD だと、ビルドの際に
もう少し調整が必要ですが、出る症状は同じです。

 ## tty/curses 版のビルドと実行
```
 $ tar xf jnethack-alpha-latest.tar.gz
 $ cd jnethack-alpha-latest/
 $ sed -i.orig 's/-lncurses/-lncursesw/' sys/unix/hints/linux
 $ sh japanese/set_lnx.sh               ## hints ファイルは "linux"
 $ gmake && gmake install
 $ cat ~/.nethackrc
 #OPTIONS=windowtype:tty
 OPTIONS=windowtype:curses
 #OPTIONS=windowtype:x11
 $ cd ~/nh/install/games/
 $ ./jnethack                           ## メッセージ中の日本語が出ません
                                        ## 端末の設定は ja_JP.eucJP です
```
![patch-before](https://github.com/user-attachments/assets/0367d2b8-de66-4ee4-b537-d1f7c1889307)

 # How to fix

sys/unix/unixmain.c において、XI18N が定義されてなくても、CURSES_GRAPHICS が
定義されていれば setlocale(3) するように修正したら直りました。

![patch-after](https://github.com/user-attachments/assets/ef74085c-51f2-4fb4-a1fd-3060d9f8fd3a)

該当部分からも明らかですが、x11 と curses を両方サポートするようにビルドした
場合は、この修正無しでも curses インターフェースは通常動作します。

マニュアル (ncurses(3)) を読んでみても、setlocale(3) で初期化しないのはマズいようです。

https://man.freebsd.org/cgi/man.cgi?query=ncurses&apropos=0&sektion=0&manpath=Debian+12.9.0&arch=default&format=html

# テスト環境
```
Linux:  Debian 12.10
        cc: gcc 12.2.0
        iconv: glibc 組込み
        ncurses: 6.5 (dpkg)

FreeBSD:14.2-RELEASE
        cc: clang 18.1.6
        iconv: libc 組込み iconv
        ncurses: 6.5

NetBSD: 10.1
        cc: gcc 10.5.0
        iconv: libc 組込み iconv
        ncurses: 6.5 (pkgsrc)
```