### PR TITLE
curses インターフェースでゲーム開始時に、キャラクターの自動選択可否メッセージがおかしく、また選択肢を手動で選べない

### DIFF
--- a/include/wincurs.h
+++ b/include/wincurs.h
@@ -201,7 +201,11 @@ extern void curses_add_inv(int, int, CHAR_P, attr_t, const char *);
 extern void curses_create_main_windows(void);
 extern void curses_init_nhcolors(void);
 extern void curses_choose_character(void);
+#if 0 /*JP*/
 extern int curses_character_dialog(const char **choices, const char *prompt);
+#else
+extern int curses_character_dialog(const char **choices, const char **choices_en, const char *prompt);
+#endif
 extern void curses_init_options(void);
 extern void curses_display_splash_window(void);
 extern void curses_cleanup(void);

--- a/win/curses/cursinit.c
+++ b/win/curses/cursinit.c
@@ -418,6 +418,9 @@ curses_choose_character()
     int count = 0;
     int cur_character = 0;
     const char **choices;
+#if 1 /*JP*/
+    const char **choices_en;
+#endif
     int *pickmap;
     char *prompt;
     char pbuf[QBUFSZ];
@@ -447,7 +450,11 @@ curses_choose_character()
     tmpchoice[count - count_off] = '\0';
     lcase(tmpchoice);
 
+#if 0 /*JP*/
     while (!isspace(prompt[count_off])) {
+#else
+    while (prompt[count_off] != '[') {
+#endif
         count_off--;
     }
 
@@ -492,6 +499,9 @@ curses_choose_character()
         for (n = 0; roles[n].name.m; n++)
             continue;
         choices = (const char **) alloc(sizeof (char *) * (n + 1));
+#if 1 /*JP*/
+        choices_en = (const char **) alloc(sizeof (char *) * (n + 1));
+#endif
         pickmap = (int *) alloc(sizeof (int) * (n + 1));
         for (;;) {
             for (n = 0, i = 0; roles[i].name.m; i++) {
@@ -501,6 +511,9 @@ curses_choose_character()
                         choices[n] = roles[i].name.f;
                     else
                         choices[n] = roles[i].name.m;
+#if 1 /*JP*/
+                    choices_en[n] = roles[i].filecode;
+#endif
                     pickmap[n++] = i;
                 }
             }
@@ -516,8 +529,15 @@ curses_choose_character()
                 panic("no available ROLE+race+gender+alignment combinations");
         }
         choices[n] = (const char *) 0;
+#if 1 /*JP*/
+        choices_en[n] = (const char *) 0;
+#endif
         if (n > 1)
+#if 0 /*JP*/
             sel = curses_character_dialog(choices,
+#else
+            sel = curses_character_dialog(choices, choices_en,
+#endif
                                         "Choose one of the following roles:");
         else
             sel = 0;
@@ -528,6 +548,9 @@ curses_choose_character()
             curses_bail(0);
         }
         free((genericptr_t) choices);
+#if 1 /*JP*/
+        free((genericptr_t) choices_en);
+#endif
         free((genericptr_t) pickmap);
     } else if (flags.initrole < 0)
         sel = ROLE_RANDOM;
@@ -568,18 +591,31 @@ curses_choose_character()
             }
 
             choices = (const char **) alloc(sizeof (char *) * (n + 1));
+#if 1 /*JP*/
+            choices_en = (const char **) alloc(sizeof (char *) * (n + 1));
+#endif
             pickmap = (int *) alloc(sizeof (int) * (n + 1));
             for (n = 0, i = 0; races[i].noun; i++) {
                 if (ok_race(flags.initrole, i,
                             flags.initgend, flags.initalign)) {
                     choices[n] = races[i].noun;
+#if 1 /*JP*/
+                    choices_en[n] = races[i].filecode;
+#endif
                     pickmap[n++] = i;
                 }
             }
             choices[n] = (const char *) 0;
+#if 1 /*JP*/
+            choices_en[n] = (const char *) 0;
+#endif
             /* Permit the user to pick, if there is more than one */
             if (n > 1)
+#if 0 /*JP*/
                 sel = curses_character_dialog(choices,
+#else
+                sel = curses_character_dialog(choices, choices_en,
+#endif
                                         "Choose one of the following races:");
             else
                 sel = 0;
@@ -591,6 +627,9 @@ curses_choose_character()
             }
             flags.initrace = sel;
             free((genericptr_t) choices);
+#if 1 /*JP*/
+            free((genericptr_t) choices_en);
+#endif
             free((genericptr_t) pickmap);
         }
         if (flags.initrace == ROLE_RANDOM) {    /* Random role */
@@ -628,18 +667,31 @@ curses_choose_character()
             }
 
             choices = (const char **) alloc(sizeof (char *) * (n + 1));
+#if 1 /*JP*/
+            choices_en = (const char **) alloc(sizeof (char *) * (n + 1));
+#endif
             pickmap = (int *) alloc(sizeof (int) * (n + 1));
             for (n = 0, i = 0; i < ROLE_GENDERS; i++) {
                 if (ok_gend(flags.initrole, flags.initrace,
                             i, flags.initalign)) {
                     choices[n] = genders[i].adj;
+#if 1 /*JP*/
+                    choices_en[n] = genders[i].filecode;
+#endif
                     pickmap[n++] = i;
                 }
             }
             choices[n] = (const char *) 0;
+#if 1 /*JP*/
+            choices_en[n] = (const char *) 0;
+#endif
             /* Permit the user to pick, if there is more than one */
             if (n > 1)
+#if 0 /*JP*/
                 sel = curses_character_dialog(choices,
+#else
+                sel = curses_character_dialog(choices, choices_en,
+#endif
                                       "Choose one of the following genders:");
             else
                 sel = 0;
@@ -651,6 +703,9 @@ curses_choose_character()
             }
             flags.initgend = sel;
             free((genericptr_t) choices);
+#if 1 /*JP*/
+            free((genericptr_t) choices_en);
+#endif
             free((genericptr_t) pickmap);
         }
         if (flags.initgend == ROLE_RANDOM) {    /* Random gender */
@@ -686,18 +741,31 @@ curses_choose_character()
             }
 
             choices = (const char **) alloc(sizeof (char *) * (n + 1));
+#if 1 /*JP*/
+            choices_en = (const char **) alloc(sizeof (char *) * (n + 1));
+#endif
             pickmap = (int *) alloc(sizeof (int) * (n + 1));
             for (n = 0, i = 0; i < ROLE_ALIGNS; i++) {
                 if (ok_align(flags.initrole, flags.initrace,
                              flags.initgend, i)) {
                     choices[n] = aligns[i].adj;
+#if 1 /*JP*/
+                    choices_en[n] = aligns[i].filecode;
+#endif
                     pickmap[n++] = i;
                 }
             }
             choices[n] = (const char *) 0;
+#if 1 /*JP*/
+            choices_en[n] = (const char *) 0;
+#endif
             /* Permit the user to pick, if there is more than one */
             if (n > 1)
+#if 0 /*JP*/
                 sel = curses_character_dialog(choices,
+#else
+                sel = curses_character_dialog(choices, choices_en,
+#endif
                                    "Choose one of the following alignments:");
             else
                 sel = 0;
@@ -709,6 +777,9 @@ curses_choose_character()
             }
             flags.initalign = sel;
             free((genericptr_t) choices);
+#if 1 /*JP*/
+            free((genericptr_t) choices_en);
+#endif
             free((genericptr_t) pickmap);
         }
         if (flags.initalign == ROLE_RANDOM) {
@@ -723,7 +794,11 @@ curses_choose_character()
 
 /* Prompt user for character race, role, alignment, or gender */
 int
+#if 0 /*JP*/
 curses_character_dialog(const char **choices, const char *prompt)
+#else
+curses_character_dialog(const char **choices, const char **choices_en, const char *prompt)
+#endif
 {
     int count, count2, ret, curletter;
     char used_letters[52];
@@ -735,7 +810,11 @@ curses_character_dialog(const char **choices, const char *prompt)
     curses_start_menu(wid);
 
     for (count = 0; choices[count]; count++) {
+#if 0 /*JP*/
         curletter = tolower(choices[count][0]);
+#else
+        curletter = tolower(choices_en[count][0]);
+#endif
         for (count2 = 0; count2 < count; count2++) {
             if (curletter == used_letters[count2]) {
                 curletter = toupper(curletter);

--- a/win/curses/cursinit.h
+++ b/win/curses/cursinit.h
@@ -11,7 +11,11 @@
 void curses_create_main_windows(void);
 void curses_init_nhcolors(void);
 void curses_choose_character(void);
+#if 0 /*JP*/
 int curses_character_dialog(const char **choices, const char *prompt);
+#else
+int curses_character_dialog(const char **choices, const char **choices_en, const char *prompt);
+#endif
 void curses_init_options(void);
 void curses_display_splash_window(void);
 void curses_cleanup(void);


### PR DESCRIPTION
# curses インターフェースでゲーム開始時に、キャラクターの自動選択可否メッセージの選択肢が二重表示される

Linux/FreeBSD で curses インターフェースでゲーム開始時に、キャラクターを
自動で選んで良いか尋ねるメッセージが出ますが、
![cursinit-patch-before1](https://github.com/user-attachments/assets/609cf5f1-b0cf-4aac-a936-c826774fa6a3)
御覧の通り選択肢が二重表示されます。

このメッセージは src/role.c に記述されてますが、メッセージの最後はこうなっています。
```
/*JP
    Strcat(buf, " for you? [ynaq] ");
*/
    Strcat(buf, "を適当に選んでよろしいですか？[ynq] ");
```
これを win/curses/cursinit.c で次のように処理しています。

(1) 角括弧内の選択肢を抜き出す (後に利用)
(2) 開き角括弧の前のホワイトスペースを '\0' で置換

しかし日本語メッセージにホワイトスペースは無いので (2) の処理に失敗しており、
結果角括弧込みで選択肢が二重に表示されています。

## How to fix

src/role.c のメッセージに手を加えても良いかも知れませんが、それはせずに

(2') 開き角括弧を '\0' で置換

としてみました。
![cursinit-patch-after1](https://github.com/user-attachments/assets/753b47de-143c-4893-9a5b-7291829773dd)
なお NetBSD でも表示が少し変 (症状は違う) ですが、この修正で直ります。

# curses インターフェースでゲーム開始時に、キャラクターを手動で選べない

Linux/FreeBSD で curses インターフェースでゲーム開始時に、キャラクターを
手動で選ぶ指示をして
```
Choose one of the following roles:
```
という画面を出すと、職業一覧は出るのですが、それらを選ぶアクセラレータ
(アルファベット) が表示されず、選択できません。
![cursinit-patch-before2](https://github.com/user-attachments/assets/1c25554b-d96b-49c0-8dbb-ca7733b8c4ca)
唯一アクセラレータが表示され選択できるのは Random と Quit の 2 つだけです。
続く種族などの選択も同じようになります。

これはキャラクター選択画面を出す curses_character_dialog() 内で、
選択肢に準じたアクセラレータを決めるのに
```
curletter = tolower(choices[count][0]);
```
としており、これが対象が日本語だとうまく動作しないためです。
なお Random と Quit は決め打ちなので、問題なく表示されます。

## How to fix

同様の問題を対策している win/tty/wintty.c を横目に考えたのですが、
curses_character_dialog() の引数の const char **choices の内容だけでは
どうにもならないと判断して、もう一つ引数を増やして対応してみました。
これで tty インターフェースと同じアクセラレータで選択できます。
![cursinit-patch-after2](https://github.com/user-attachments/assets/1443104e-4c2c-4afc-abdb-1f1af4b7974d)
なお NetBSD だとこの修正無しでもアクセラレータが一応表示され、手動で選べますが、
アクセラレータが選択肢に無関係に a b c d ... となります (アイテム表示と同じ)。
この修正で本来の表示になります。

# テスト環境

再現方法も含めて #15 と同じなので省略します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - キャラクター選択画面で、選択肢ごとに内部コード（英語表記）を扱えるようになりました。これにより、選択メニューのキー割り当てが改善されています。

- **改善**
  - メニュー選択時のキー割り当てが、表示名ではなく内部コードの先頭文字を基準にするようになり、重複時の処理も最適化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->