### PR TITLE
curses インターフェースで一部の日本語メッセージの末尾が 1 文字欠落する (NetBSD)

### DIFF
--- a/win/curses/cursmisc.c
+++ b/win/curses/cursmisc.c
@@ -691,7 +691,11 @@ curses_rtrim(char *str)
     char *s;
 
     for (s = str; *s != '\0'; ++s);
+#if 0 /*JP*/
     for (--s; isspace(*s) && s > str; --s);
+#else
+    for (--s; isspace_8(*s) && s > str; --s);
+#endif
     if (s == str)
         *s = '\0';
     else


### PR DESCRIPTION
# NetBSD で curses インターフェースでゲームを実行すると、一部の日本語メッセージの末尾が 1 文字欠落する
例えば職業選択の画面で、
```
 武闘家 -> 武闘
 僧侶 -> 僧
 侍 -> (何も表示されない)
```
となることが多いです。ただしどれが欠けるかは、実行の度に若干変化します。
なお FreeBSD や Linux だとこのような症状は出ません。
スクリーンショットをいくつか上げます。
![netbsd-before1](https://github.com/user-attachments/assets/e954260b-3acd-4c71-9bc4-7d1aaa19417f)
![netbsd-before2](https://github.com/user-attachments/assets/b4e31af2-df3a-48a1-9265-6f83cc08fb03)
![netbsd-before3](https://github.com/user-attachments/assets/0ac18f72-65ee-4f48-8224-6fb37b02e661)

## テスト環境
```
NetBSD 10.1
  cc: gcc7
  iconv: libc 組込み iconv
  ncurses: 6.5 (pkgsrc)
```

## How to repeat
あらかじめ ncurses と gmake をインストールしておきます。
```
 $ tar xf jnethack-alpha-latest.tar.gz
 $ cd jnethack-alpha-latest/
```
ここでヒントファイルを修正します。ncurses のライブラリ関連と、コマンドのパスや
オプションの修正です。
```
--- ./sys/unix/hints/linux.orig 2025-05-21 03:13:17.000000000 +0900
+++ ./sys/unix/hints/linux      2025-05-23 21:19:03.125617312 +0900
@@ -18,11 +18,11 @@
 
 
 
-POSTINSTALL=cp -n sys/unix/sysconf $(INSTDIR)/sysconf; $(CHOWN) $(GAMEUID) $(INSTDIR)/sysconf; $(CHGRP) $(GAMEGRP) $(INSTDIR)/sysconf; chmod $(VARFILEPERM) $(INSTDIR)/sysconf;
+POSTINSTALL=cp -i sys/unix/sysconf $(INSTDIR)/sysconf; $(CHOWN) $(GAMEUID) $(INSTDIR)/sysconf; $(CHGRP) $(GAMEGRP) $(INSTDIR)/sysconf; chmod $(VARFILEPERM) $(INSTDIR)/sysconf;
 
-CFLAGS=-g -O -I../include -DNOTPARMDECL
+CFLAGS=-g -O -I/usr/pkg/include/ncurses -I/usr/pkg/include -I../include -DNOTPARMDECL
 CFLAGS+=-DDLB
-CFLAGS+=-DCOMPRESS=\"/bin/gzip\" -DCOMPRESS_EXTENSION=\".gz\"
+CFLAGS+=-DCOMPRESS=\"/usr/bin/gzip\" -DCOMPRESS_EXTENSION=\".gz\"
 CFLAGS+=-DSYSCF -DSYSCF_FILE=\"$(HACKDIR)/sysconf\" -DSECURE
 CFLAGS+=-DTIMED_DELAY
 CFLAGS+=-DHACKDIR=\"$(HACKDIR)\"
@@ -37,7 +37,7 @@
 
 LINK=$(CC)
 # Only needed for GLIBC stack trace:
-LFLAGS=-rdynamic
+LFLAGS=-rdynamic -L/usr/pkg/lib -rpath=/usr/pkg/lib
 
 WINSRC = $(WINTTYSRC) $(WINCURSESSRC)
 WINOBJ = $(WINTTYOBJ) $(WINCURSESOBJ)
@@ -47,7 +47,7 @@
 #WINSRC += tile.c
 #WINOBJ += tile.o
 
-WINTTYLIB=-lncurses -ltinfo
+WINTTYLIB=-lncurses
 
 CHOWN=true
 CHGRP=true
```
次にインストールと実行をします。
```
 $ sh japanese/set_lnx.sh
 $ gmake install
 $ cd ~/nh/install/games/
 $ cat ~/.nethackrc
 #OPTIONS=windowtype:tty
 OPTIONS=windowtype:curses
 #OPTIONS=windowtype:x11
 $ ./jnethack                   # 一部の日本語メッセージの末尾が欠けます
```

## How to fix
win/curses/cursmisc.c で curses_rtrim() という関数が定義されています。
```
void
curses_rtrim(char *str)
{
    char *s;

    for (s = str; *s != '\0'; ++s);
    for (--s; isspace(*s) && s > str; --s);
    if (s == str)
        *s = '\0';
    else
        *(++s) = '\0';
}
```
与えられた文字列の末尾のホワイトスペースを、文字列末尾から辿っていますが、
日本語文字列だと isspace() は対応できません。

幸い japanese/jlib.c で isspace_8() という「8ビットスルーなisspace()」が定義されています。
isspace() の代わりにこちらを実行するようにしたところ、日本語文字列の欠けは無くなりました。

(何故か症状が出なかった) FreeBSD と Linux でもテストしましたが、問題なく動作しました。
![netbsd-after1](https://github.com/user-attachments/assets/bd257201-5075-4622-9a49-30f5a2987d9e)
![netbsd-after2](https://github.com/user-attachments/assets/6ceb5379-b523-4755-bb79-fdf9bd5efabc)
![netbsd-after3](https://github.com/user-attachments/assets/08137361-3880-46d5-9403-b87f0f80a00d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 文字列のトリミング処理において、空白文字の判定方法が改善され、より正確に末尾の空白が削除されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->