### PR TITLE
[curses] 文字列の折り返し表示 / 入力文字のエコーバック / Backspace による入力文字削除の日本語対応、及び more プロンプトの不具合修正

### DIFF
--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -140,6 +140,10 @@ curses_message_win_puts(const char *message, boolean recursed)
         curses_toggle_color_attr(win, NONE, A_BOLD, ON);
 
     /* will this message fit as-is or do we need to split it? */
+#if 1 /*JP*/
+    /* +1 safety mergin for trailing ">>_".  see curses_block() */
+    width--;
+#endif
     if (mx == border_space && message_length > width - 2) {
         /* split needed */
         tmpstr = curses_break_str(message, (width - 2), 1);
@@ -472,6 +476,9 @@ curses_message_win_getline(const char *prompt, char *answer, int buffer)
     char *tmpstr; /* for free() */
     int maxy, maxx; /* linewrap / scroll */
     int ch;
+#if 1 /*JP*/
+    int tmpch = 0;
+#endif
     int border_space = 0;
     int ltmp, len; /* of answer string */
     boolean border = curses_window_has_border(MESSAGE_WIN);
@@ -663,12 +670,23 @@ curses_message_win_getline(const char *prompt, char *answer, int buffer)
         case KEY_DC: /* delete-character */
         case '\b': /* ^H (Backspace: '\010') */
         case KEY_BACKSPACE:
+#if 1 /*JP*/
+        moreback:
+#endif
             if (len < 1) {
                 len = 1;
                 mx = promptx;
             }
             p_answer[--len] = '\0';
             mvwaddch(win, my, --mx, ' ');
+#if 1 /*JP*/
+            {
+                int n;
+                n = is_kanji2(p_answer, len);
+                if (n > 0)
+                    goto moreback;
+            }
+#endif
             /* try to unwrap back to the previous line if there is one */
             if (nlines > 1 && (int) strlen(linestarts[nlines - 2]) < width) {
                 mvwaddstr(win, my - 1, border_space, linestarts[nlines - 2]);
@@ -687,12 +705,42 @@ curses_message_win_getline(const char *prompt, char *answer, int buffer)
             }
             break;
         default:
+#if 0 /*JP*/
             p_answer[len++] = ch;
             if (len >= buffer)
                 len = buffer - 1;
             else
                 mvwaddch(win, my, mx, ch);
             p_answer[len] = '\0';
+#else
+            if (tmpch == 0) {
+                if (is_kanji(ch)) {
+                    tmpch = ch;
+                } else {
+                    p_answer[len++] = ch;
+                    if (len >= buffer)
+                        len = buffer - 1;
+                    else
+                        mvwaddch(win, my, mx, ch);
+                    p_answer[len] = '\0';
+                }
+            } else {
+                p_answer[len++] = tmpch;
+                if (len >= buffer)
+                    len = buffer - 1;
+                else
+                    mvwaddch(win, my, mx, tmpch);
+
+                p_answer[len++] = ch;
+                if (len >= buffer)
+                    len = buffer - 1;
+                else
+                    mvwaddch(win, my, mx, ch);
+                p_answer[len] = '\0';
+
+                tmpch = 0;
+            }
+#endif
         }
     }
 

--- a/win/curses/cursmisc.c
+++ b/win/curses/cursmisc.c
@@ -307,6 +307,9 @@ curses_break_str(const char *str, int width, int line_num)
     char substr[strsize];
     char curstr[strsize];
     char tmpstr[strsize];
+#if 1 /*JP*/
+    int prefix_space;
+#endif
 
     strcpy(substr, str);
 #else
@@ -334,6 +337,10 @@ curses_break_str(const char *str, int width, int line_num)
         for (count = 0; count <= width; count++) {
             if (substr[count] == ' ') {
                 last_space = count;
+#if 1 /*JP*/
+            } else if (is_kanji1(substr, count)) {
+                last_space = count;
+#endif
             } else if (substr[count] == '\0') {
                 last_space = count;
                 break;
@@ -349,10 +356,23 @@ curses_break_str(const char *str, int width, int line_num)
         if (substr[count] == '\0') {
             break;
         }
+#if 0 /*JP*/
         for (count = (last_space + 1); count < (int) strlen(substr); count++) {
             tmpstr[count - (last_space + 1)] = substr[count];
         }
         tmpstr[count - (last_space + 1)] = '\0';
+#else
+        if (substr[last_space] == ' ') {
+            prefix_space = 1;
+        } else {
+            prefix_space = 0;
+        }
+
+        for (count = (last_space + prefix_space); count < (int) strlen(substr); count++) {
+            tmpstr[count - (last_space + prefix_space)] = substr[count];
+        }
+        tmpstr[count - (last_space + prefix_space)] = '\0';
+#endif
         strcpy(substr, tmpstr);
     }
 
@@ -378,6 +398,9 @@ curses_str_remainder(const char *str, int width, int line_num)
 #if __STDC_VERSION__ >= 199901L
     char substr[strsize];
     char tmpstr[strsize];
+#if 1 /*JP*/
+    int prefix_space;
+#endif
 
     strcpy(substr, str);
 #else
@@ -404,6 +427,10 @@ curses_str_remainder(const char *str, int width, int line_num)
         for (count = 0; count <= width; count++) {
             if (substr[count] == ' ') {
                 last_space = count;
+#if 1 /*JP*/
+            } else if (is_kanji1(substr, count)) {
+                last_space = count;
+#endif
             } else if (substr[count] == '\0') {
                 last_space = count;
                 break;
@@ -415,10 +442,23 @@ curses_str_remainder(const char *str, int width, int line_num)
         if (substr[last_space] == '\0') {
             break;
         }
+#if 0 /*JP*/
         for (count = (last_space + 1); count < (int) strlen(substr); count++) {
             tmpstr[count - (last_space + 1)] = substr[count];
         }
         tmpstr[count - (last_space + 1)] = '\0';
+#else
+        if (substr[last_space] == ' ') {
+            prefix_space = 1;
+        } else {
+            prefix_space = 0;
+        }
+
+        for (count = (last_space + prefix_space); count < (int) strlen(substr); count++) {
+            tmpstr[count - (last_space + prefix_space)] = substr[count];
+        }
+        tmpstr[count - (last_space + prefix_space)] = '\0';
+#endif
         strcpy(substr, tmpstr);
     }
 


### PR DESCRIPTION
### (1) 文字列の折り返し表示の日本語対応 (win/curses/cursmisc.c)

表示文字列が表示エリアの幅よりも長い場合、大抵は折り返し表示をするのですが、
現状はマルチバイト文字を考慮していないため、マルチバイト文字が泣き別れする
場合があります。

英語版では基本的に、文字列中のホワイトスペースを順次マークしていって、
表示幅内で最後にマッチしたホワイトスペースで折り返すようになってます。
ただしホワイトスペースが無ければ、表示幅を基準に折り返してしまいますが、
表示幅に収まらない日本語文字列の多くは、これに該当します。

そのため、泣き別れ、かつ読み飛ばし (後述します) で一文字消えてしまったり、
<img width="600" height="200" alt="jnethack_wordwrap_2 crop" src="https://github.com/user-attachments/assets/2246cc0a-1958-4e1f-9e8a-323f13478ba2" />
泣き別れは無くても、読み飛ばしで折り返し行が文字化けしたりします。
<img width="600" height="200" alt="jnethack_wordwrap_1 crop" src="https://github.com/user-attachments/assets/40377001-0151-43ff-8c95-cd1c967c0907" />

そこで、マルチバイト文字の 1 バイト目に当たった場合、そこもマークするように
修正してみました。

また英語版では、折り返した 2 行目以降の先頭バイトはホワイトスペースであると
みなしているようで、無条件に読み飛ばしています。上記修正後それでは困るので、
先頭バイトがホワイトスペースである場合のみ読み飛ばすように修正しました。

修正後は問題なく表示されます。

一文字消えたりしません。
<img width="600" height="200" alt="jnethack_wordwrap_fix_2 crop" src="https://github.com/user-attachments/assets/24d15744-4af8-4476-ac4c-6de4b04a3e14" />
文字化けしません。
<img width="600" height="200" alt="jnethack_wordwrap_fix_1 crop" src="https://github.com/user-attachments/assets/d9294adc-50a0-4fe5-9d2a-007dbd3bca27" />

### (2) 日本語入力時に入力文字がエコーバックしない問題、入力文字削除機能の日本語対応、more プロンプトが画面に残る問題の修正 (win/curses/cursmesg.c)

現状、(願いの杖などで) 日本語入力をした時に入力文字がエコーバックしません。
文字の幅だけカーソルが移動するのみです。入力自体は問題なく読み取られます。

エコーバックしません。
<img width="500" height="100" alt="jnethack_echoback_1 crop" src="https://github.com/user-attachments/assets/c8915de2-17e9-4325-9cc9-a157b0af9d50" />
入力は反映されます。
<img width="500" height="100" alt="jnethack_echoback_2 crop" src="https://github.com/user-attachments/assets/77059295-50ef-4689-854b-e095d23a1b4c" />

これは入力された文字を、ncurses の関数 mvwaddch() で 1 バイト単位で
画面に書き込み、表示させようとしている為のようです。

ncurses のマニュアル curs_addch(3X) には次の記述があります。
```
| PORTABILITY
(snip)
|  Character Set
(snip)
|   Depending on the locale settings, ncurses will inspect the byte passed
|   in each call to waddch, and check if the latest call will continue a
|   multibyte sequence.  When a character is complete, ncurses displays the
|   character and moves to the next position in the screen.
```
(https://man.freebsd.org/cgi/man.cgi?query=curs_addch&apropos=0&sektion=0&manpath=FreeBSD+15.0-RELEASE&arch=default&format=html#PORTABILITY)

これを読む限り、マルチバイト文字は他の関数を挟まずに、mvwaddch() で連続して
書き込めば、locale に従って適切に処理されるようです。

そこで日本語の 1 バイト目 2 バイト目が揃ってから、英語版の書き込みコードで
連続して書き込むようにしたところ、日本語入力文字がエコーバックされるように
なりました。

御覧の通りベタ書きの修正ですが、例外処理等に自信が無いので...。

エコーバックします.
<img width="500" height="100" alt="jnethack_echoback_fix_1 crop" src="https://github.com/user-attachments/assets/9604a46b-b24b-43f6-95a3-63a48b33578d" />
入力も反映されます。
<img width="500" height="100" alt="jnethack_echoback_fix_2 crop" src="https://github.com/user-attachments/assets/4b2f2799-a0c2-4085-a9b6-c3a05dbf0747" />

なお上記マニュアルにもあるのですが、これは ncurses 独自の機能なので、別の
curses 実装だとたぶんうまくいきません。UNIX 系 OS なら ncurses を入れれば
よいのですが、日本語対応させた (Windows 用の) PDCurses で動かしたい場合は、
別の処理が必要だと思います。

**

次に、バックスペースによる入力文字の削除機能の日本語対応です。

現状は 1 バイト単位の削除になっています。

削除前
<img width="600" height="80" alt="jnethack_deletion_1 crop" src="https://github.com/user-attachments/assets/0eefc72f-8e3c-4eed-a54c-20cbd7207139" />
バックスペース 1 回目、1 バイト目削除
<img width="600" height="80" alt="jnethack_deletion_2 crop" src="https://github.com/user-attachments/assets/6fb0a5e5-0c89-46de-8200-4cbe96178db8" />
バックスペース 2 回目、2 バイト目削除
<img width="600" height="80" alt="jnethack_deletion_3 crop" src="https://github.com/user-attachments/assets/baee1f22-4a6e-4d33-a39a-f763f1416fba" />

これを文字単位で削除するように、同様の修正がされた win/tty/getline.c を横目に
実装してみました。

削除前
<img width="600" height="80" alt="jnethack_deletion_fix_1 crop" src="https://github.com/user-attachments/assets/f64c639f-931a-4807-a331-b9cab0ce99e2" />
バックスペース 1 回目、1 文字削除
<img width="600" height="80" alt="jnethack_deletion_fix_2 crop" src="https://github.com/user-attachments/assets/541c8e1b-9380-4bbd-94d9-7ac0eb35c5a8" />

**

最後に、メッセージウィンドウの more プロンプト表示が乱れる問題です。

メッセージウィンドウで 1 画面に収まらない文字列を表示する時に、ぺージャー風の
more プロンプトが表示されます。このプロンプトは 「\>\>\_」(「\_」はカーソル)
というもので、表示には 3 文字分の表示エリアが必要です。

プロンプトは表示最終行の末尾に表示されるので、表示文字列は、表示エリアより
最長でも 3 文字短くする必要がある筈です。

筈なのですが、メッセージウィンドウに文字列を出力する関数
curses_message_win_puts() では現状、
```
| /* -2: room for trailing ">>" (if More>> is needed) or leading "  "
|    (if combining this message with preceding one) */
| linespace = (width - 1) - 2 - (mx - border_space);
```
という感じで余白を 2 文字しか取ってません。

その結果、表示最終行の文字列長が表示幅いっぱい (表示エリア - 2 文字)
である場合、プロンプトが余白の 2 文字に押し込められてしまいます。

アイテム選択
<img width="600" height="100" alt="jnethack_prompt_ja_1 crop" src="https://github.com/user-attachments/assets/23455bc6-e92b-443e-9fcc-0465f3cb88e4" />
プロンプトが押し込められる
<img width="600" height="100" alt="jnethack_prompt_ja_2 crop" src="https://github.com/user-attachments/assets/8f3c78d2-5525-4b12-95d8-aff16fa257e1" />

その後はメッセージを読み進めても、プロンプトの一部が残ったままになります。
残りの表示を ESC でキャンセルして、Ctrl-R で端末を再描画すると、
プロンプトの残骸は消えますが、他の表示の一部が乱れます。

ESC でキャンセル
<img width="600" height="100" alt="jnethack_prompt_ja_3 crop" src="https://github.com/user-attachments/assets/eb701399-f7d0-4163-a79e-7561fbd545be" />
Ctrl-R で一部表示が乱れる
<img width="600" height="100" alt="jnethack_prompt_ja_4 crop" src="https://github.com/user-attachments/assets/1cd3ce68-97bb-401e-842a-9112e50d8f08" />

実は英語版でも、同じ条件で不具合が起きます。プロンプトは表示されますし、
表示の乱れもありませんが、代わりに文字列末尾が 1 文字プロンプトに食われて
読めなくなります。

選択
<img width="600" height="100" alt="jnethack_prompt_en_1 crop" src="https://github.com/user-attachments/assets/4b527d99-5402-4bfe-945c-43c27fbf5463" />
プロンプトで一文字欠ける
<img width="600" height="100" alt="jnethack_prompt_en_2 crop" src="https://github.com/user-attachments/assets/e5aaecbe-6e42-4680-8ca7-9adcfd2849c5" />
ESC でキャンセルしても欠けたまま
<img width="600" height="100" alt="jnethack_prompt_en_3 crop" src="https://github.com/user-attachments/assets/8874ba65-c6fd-43f5-bf3a-1f91f6d4ee26" />
Ctrl-R で変化無し
<img width="600" height="100" alt="jnethack_prompt_en_4 crop" src="https://github.com/user-attachments/assets/a445a00a-bfc2-4505-b416-93118cb25475" />

対策として、上記箇所でもう 1 文字多く余白を取るように修正をしました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 日本語（漢字）テキストのメッセージ入力処理を改善しました
  * マルチバイト文字の削除時の処理を最適化しました
  * テキスト折り返しロジックを日本語テキストに対応させました
  * メッセージ表示の安全性マージンを向上させました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->