### PR TITLE
[curses/tty] オプション設定メニューで選択肢の複数選択ができない

### DIFF
--- a/src/botl.c
+++ b/src/botl.c
@@ -2519,7 +2519,11 @@ query_conditions()
                  valid_conditions[i].id, MENU_UNSELECTED);
     }
 
+#if 0 /*JP*/
     end_menu(tmpwin, "Choose status conditions");
+#else
+    end_menu(tmpwin, "ステータス状態を選んでください");
+#endif
 
     res = select_menu(tmpwin, PICK_ANY, &picks);
     destroy_nhwindow(tmpwin);
@@ -3737,23 +3741,23 @@ choose_value:
 /*JP
         Sprintf(colorqry, "Choose a color for when %s is '%s':",
 */
-        Sprintf(colorqry, "%sが'%s'の時の色を選択:",
+        Sprintf(colorqry, "%sが'%s'の時の色を選んでください:",
                 initblstats[fld].fldname, hilite.textmatch);
 /*JP
         Sprintf(attrqry, "Choose attribute for when %s is '%s':",
 */
-        Sprintf(attrqry, "%sが'%s'の時の属性を選択:",
+        Sprintf(attrqry, "%sが'%s'の時の属性を選んでください:",
                 initblstats[fld].fldname, hilite.textmatch);
     } else if (behavior == BL_TH_ALWAYS_HILITE) {
 /*JP
         Sprintf(colorqry, "Choose a color to always hilite %s:",
 */
-        Sprintf(colorqry, "常に%sをハイライトする色を選択:",
+        Sprintf(colorqry, "常に%sをハイライトする色を選んでください:",
                 initblstats[fld].fldname);
 /*JP
         Sprintf(attrqry, "Choose attribute to always hilite %s:",
 */
-        Sprintf(attrqry, "常に%sをハイライトする属性を選択:",
+        Sprintf(attrqry, "常に%sをハイライトする属性を選んでください:",
                 initblstats[fld].fldname);
     }
 

--- a/src/options.c
+++ b/src/options.c
@@ -1915,10 +1915,18 @@ const char *prompt;
     anything any;
     int i, pick_cnt;
     menu_item *picks = (menu_item *) 0;
+#if 0 /*JP*/
     boolean allow_many = (prompt && !strncmpi(prompt, "Choose", 6));
+#else
+    boolean allow_many = (prompt && strstri(prompt, "選んでください"));
+#endif
     int default_attr = ATR_NONE;
 
+#if 0 /*JP*/
     if (prompt && strstri(prompt, "menu headings"))
+#else
+    if (prompt && strstri(prompt, "メニューヘッダ"))
+#endif
         default_attr = iflags.menu_headings;
     tmpwin = create_nhwindow(NHW_MENU);
     start_menu(tmpwin);


### PR DESCRIPTION
curses インターフェースと tty インターフェースの両方で再現します。
文中では tty インターフェースの表示を引用しました。

jnethack を実行中に、'O' を押すとオプション設定メニューが出ますが、
選択肢を複数選択できるはずの項目で、それができません。

例えばステータスハイライトの設定メニューで、
```
'O' -> status hilite rules ("Other settings:" にあります)
     -> condition
      -> 新しいハイライトを追加
       -> foodPois, termIll, blind (どれでもよいが、複数選択)
        -> red
```
と選択していくと、次のメニューになります。
```
                       条件foodPois+termIll+blindのときの属性を選んでください:
                       
                       a + none
                       b - bold
                       c - dim
                       d - underline
                       e - blink
                       f - inverse
                       (end) 
```
ここで例えば bold かつ inverse を選ぼうとしてまず 'b' を押すと、
'f' を押す前に次のメニューになってしまい、複数選択ができません。
```
                               現在のconditionのハイライト:
                               
                               a - condition/foodPois+termIll+blind/red&normal
                               
                               X - 選択したハイライトを削除
                               Z - 新しいハイライトを追加
                               (end) 
```
しかも bold ではなく normal になっています。
前のメニューで none / bold / dim / underline / blink / inverse の
どれを選択しても、 normal か inverse にしかなりません。

本来なら (nethack-3.6.7)、
```
                       Choose attribute for conditions foodPois+termIll+blind:
                       
                       a + none
                       b + bold
                       c - dim
                       d - underline
                       e - blink
                       f + inverse
                       (end) 
```
このように複数選択が可能で、
```
                         Current condition hilites:
                         
                         a - condition/foodPois+termIll+blind/red&bold+inverse
                         
                         X - Remove selected hilites
                         Z - Add a new hilite
                         (end) 
```
選択が反映されるはずなのですが。

## How to fix
### 関数の修正

この属性 (attribute) を選択するメニューを担当しているのが
query_attr() (src/options.c) なのですが、関数の冒頭で次のような
処理をしています。
```
| int
| query_attr(prompt)
| const char *prompt;
| {
(snip)
|     boolean allow_many = (prompt && !strncmpi(prompt, "Choose", 6));
 ```
プロンプト文字列が "Choose" で始まっていたら allow_many を設定しています。
これは複数選択を認めるかどうかの真偽値フラグですが、プロンプト文字列が日本語に
翻訳されているとマッチしないので、複数選択が出来なくなります。

(前述のステータスハイライトの設定で、foodPois / termIll / blind が現状でも
複数選択できているのは、この設定メニューだけプロンプト文字列が未訳なためです)

そこでこの部分を
```
|     boolean allow_many = (prompt && strstri(prompt, "選んでください"));
```
としました。

またこの処理の直後の "メニューヘッダ" は、メニューヘッダの現在のハイライト
設定を、設定メニューのデフォルト値に反映させるために必要なので、同様の
修正をしました.

### 翻訳の変更と追加

プロンプト文字列の原文の "Choose" が "選んでください" と訳されている必要が
あるので、一部の日本語訳を変更しました (attrqry のほうです)。

colorqry のほうはメニュ−の挙動には関係ないのですが (元々単一選択のみ)、
訳語の統一の意味で変更してみました。

また前述の未訳の一文を翻訳しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ユーザーインターフェース内のプロンプトおよびメニューメッセージが日本語に対応しました。ステータス条件選択、色・属性選択など、各種インタラクション時の表示が日本語で表示されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->