### PR TITLE
[curses] 文字列の折り返し表示の日本語対応

### DIFF
--- a/win/curses/cursmisc.c
+++ b/win/curses/cursmisc.c
@@ -307,6 +307,9 @@ curses_break_str(const char *str, int width, int line_num)
     char substr[strsize];
     char curstr[strsize];
     char tmpstr[strsize];
+#if 1 /*JP*/
+    int prefix_space;
+#endif
 
     strcpy(substr, str);
 #else
@@ -334,6 +337,10 @@ curses_break_str(const char *str, int width, int line_num)
         for (count = 0; count <= width; count++) {
             if (substr[count] == ' ') {
                 last_space = count;
+#if 1 /*JP*/
+            } else if (is_kanji1(substr, count)) {
+                last_space = count;
+#endif
             } else if (substr[count] == '\0') {
                 last_space = count;
                 break;
@@ -349,10 +356,23 @@ curses_break_str(const char *str, int width, int line_num)
         if (substr[count] == '\0') {
             break;
         }
+#if 0 /*JP*/
         for (count = (last_space + 1); count < (int) strlen(substr); count++) {
             tmpstr[count - (last_space + 1)] = substr[count];
         }
         tmpstr[count - (last_space + 1)] = '\0';
+#else
+        if (substr[last_space] == ' ') {
+            prefix_space = 1;
+        } else {
+            prefix_space = 0;
+        }
+
+        for (count = (last_space + prefix_space); count < (int) strlen(substr); count++) {
+            tmpstr[count - (last_space + prefix_space)] = substr[count];
+        }
+        tmpstr[count - (last_space + prefix_space)] = '\0';
+#endif
         strcpy(substr, tmpstr);
     }
 
@@ -378,6 +398,9 @@ curses_str_remainder(const char *str, int width, int line_num)
 #if __STDC_VERSION__ >= 199901L
     char substr[strsize];
     char tmpstr[strsize];
+#if 1 /*JP*/
+    int prefix_space;
+#endif
 
     strcpy(substr, str);
 #else
@@ -404,6 +427,10 @@ curses_str_remainder(const char *str, int width, int line_num)
         for (count = 0; count <= width; count++) {
             if (substr[count] == ' ') {
                 last_space = count;
+#if 1 /*JP*/
+            } else if (is_kanji1(substr, count)) {
+                last_space = count;
+#endif
             } else if (substr[count] == '\0') {
                 last_space = count;
                 break;
@@ -415,10 +442,23 @@ curses_str_remainder(const char *str, int width, int line_num)
         if (substr[last_space] == '\0') {
             break;
         }
+#if 0 /*JP*/
         for (count = (last_space + 1); count < (int) strlen(substr); count++) {
             tmpstr[count - (last_space + 1)] = substr[count];
         }
         tmpstr[count - (last_space + 1)] = '\0';
+#else
+        if (substr[last_space] == ' ') {
+            prefix_space = 1;
+        } else {
+            prefix_space = 0;
+        }
+
+        for (count = (last_space + prefix_space); count < (int) strlen(substr); count++) {
+            tmpstr[count - (last_space + prefix_space)] = substr[count];
+        }
+        tmpstr[count - (last_space + prefix_space)] = '\0';
+#endif
         strcpy(substr, tmpstr);
     }
 


### PR DESCRIPTION
### 文字列の折り返し表示の日本語対応 (win/curses/cursmisc.c)

表示文字列が表示エリアの幅よりも長い場合、大抵は折り返し表示をするのですが、
現状はマルチバイト文字を考慮していないため、マルチバイト文字が泣き別れする
場合があります。

英語版では基本的に、文字列中のホワイトスペースを順次マークしていって、
表示幅内で最後にマッチしたホワイトスペースで折り返すようになってます。

ただしホワイトスペースが無ければ、表示幅を基準に折り返してしまいます。
表示幅に収まらない日本語文字列の多くは、これに該当します。

そのため、泣き別れ、かつ読み飛ばし (後述します) で一文字消えてしまったり、
<img width="600" height="200" alt="jnethack_wordwrap_2 crop" src="https://github.com/user-attachments/assets/2246cc0a-1958-4e1f-9e8a-323f13478ba2" />
泣き別れは無くても、読み飛ばしで折り返し行が文字化けしたりします。
<img width="600" height="200" alt="jnethack_wordwrap_1 crop" src="https://github.com/user-attachments/assets/40377001-0151-43ff-8c95-cd1c967c0907" />

そこで、文字列中でマルチバイト文字の 1 バイト目に当たった場合、そこもマークするように
修正してみました。

また英語版では、折り返した 2 行目以降の先頭バイトはホワイトスペースであると
みなしているようで、無条件に読み飛ばしています。上記修正後それでは困るので、
先頭バイトがホワイトスペースである場合のみ読み飛ばすように修正しました。

修正後は問題なく表示されます。

一文字消えたりしません。
<img width="600" height="200" alt="jnethack_wordwrap_fix_2 crop" src="https://github.com/user-attachments/assets/24d15744-4af8-4476-ac4c-6de4b04a3e14" />
文字化けしません。
<img width="600" height="200" alt="jnethack_wordwrap_fix_1 crop" src="https://github.com/user-attachments/assets/d9294adc-50a0-4fe5-9d2a-007dbd3bca27" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* **テキスト表示の改善**
  * 日本語テキストの行折り返し処理を最適化しました。漢字を区切り位置として適切に認識するようになります。
  * 行分割後のスペース処理が改善され、より自然なテキスト表示が実現します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->