### PR TITLE
[curses] 日本語入力時に入力文字がエコーバックしない

### DIFF
--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -472,6 +472,9 @@ curses_message_win_getline(const char *prompt, char *answer, int buffer)
     char *tmpstr; /* for free() */
     int maxy, maxx; /* linewrap / scroll */
     int ch;
+#if 1 /*JP*/
+    int tmpch = 0;
+#endif
     int border_space = 0;
     int ltmp, len; /* of answer string */
     boolean border = curses_window_has_border(MESSAGE_WIN);
@@ -687,12 +690,42 @@ curses_message_win_getline(const char *prompt, char *answer, int buffer)
             }
             break;
         default:
+#if 0 /*JP*/
             p_answer[len++] = ch;
             if (len >= buffer)
                 len = buffer - 1;
             else
                 mvwaddch(win, my, mx, ch);
             p_answer[len] = '\0';
+#else
+            if (tmpch == 0) {
+                if (is_kanji(ch)) {
+                    tmpch = ch;
+                } else {
+                    p_answer[len++] = ch;
+                    if (len >= buffer)
+                        len = buffer - 1;
+                    else
+                        mvwaddch(win, my, mx, ch);
+                    p_answer[len] = '\0';
+                }
+            } else {
+                p_answer[len++] = tmpch;
+                if (len >= buffer)
+                    len = buffer - 1;
+                else
+                    mvwaddch(win, my, mx, tmpch);
+
+                p_answer[len++] = ch;
+                if (len >= buffer)
+                    len = buffer - 1;
+                else
+                    mvwaddch(win, my, mx, ch);
+                p_answer[len] = '\0';
+
+                tmpch = 0;
+            }
+#endif
         }
     }
 


### PR DESCRIPTION
### 日本語入力時に入力文字がエコーバックしない (win/curses/cursmesg.c)

現状、(願いの杖などで) 日本語入力をした時に入力文字がエコーバックしません。
文字の幅だけカーソルが移動するのみです。入力自体は問題なく読み取られます。

エコーバックしません。
<img width="500" height="100" alt="jnethack_echoback_1 crop" src="https://github.com/user-attachments/assets/c8915de2-17e9-4325-9cc9-a157b0af9d50" />
入力は反映されます。
<img width="500" height="100" alt="jnethack_echoback_2 crop" src="https://github.com/user-attachments/assets/77059295-50ef-4689-854b-e095d23a1b4c" />

これは入力された文字を、ncurses の関数 mvwaddch() で 1 バイト単位で
画面に書き込み、表示させようとしている為のようです。

ncurses のマニュアル curs_addch(3X) には次の記述があります。
```
| PORTABILITY
(snip)
|  Character Set
(snip)
|   Depending on the locale settings, ncurses will inspect the byte passed
|   in each call to waddch, and check if the latest call will continue a
|   multibyte sequence.  When a character is complete, ncurses displays the
|   character and moves to the next position in the screen.
```
(https://man.freebsd.org/cgi/man.cgi?query=curs_addch&apropos=0&sektion=0&manpath=FreeBSD+15.0-RELEASE&arch=default&format=html#PORTABILITY)

これを読む限り、マルチバイト文字は他の関数を挟まずに、mvwaddch() で連続して
書き込めば、locale に従って適切に処理されるようです。

そこで日本語の 1 バイト目 2 バイト目が揃ってから、英語版の書き込みコードで
連続して書き込むようにしたところ、日本語入力文字がエコーバックされるように
なりました。

御覧の通りベタ書きの修正ですが、例外処理等に自信が無いので...。

エコーバックします.
<img width="500" height="100" alt="jnethack_echoback_fix_1 crop" src="https://github.com/user-attachments/assets/9604a46b-b24b-43f6-95a3-63a48b33578d" />
入力も反映されます。
<img width="500" height="100" alt="jnethack_echoback_fix_2 crop" src="https://github.com/user-attachments/assets/4b2f2799-a0c2-4085-a9b6-c3a05dbf0747" />

なお上記マニュアルにもあるのですが、これは ncurses 独自の機能なので、別の
curses 実装だとたぶんうまくいきません。UNIX 系 OS なら ncurses を入れれば
よいのですが、例えば日本語対応させた (Windows 用の) PDCurses で動かしたい
場合は、別の処理が必要だと思います。

(nethack の curses インターフェースは PDCurses にも対応しているようです)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * マルチバイト文字（漢字）の入力処理が改善されました。テキスト入力時の日本語入力がより正確に処理されるようになり、既存のASCII文字の入力との互換性も完全に保たれています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->