### PR TITLE
[curses] Backspace による入力文字削除機能の日本語対応

### DIFF
--- a/win/curses/cursmesg.c
+++ b/win/curses/cursmesg.c
@@ -663,12 +663,23 @@ curses_message_win_getline(const char *prompt, char *answer, int buffer)
         case KEY_DC: /* delete-character */
         case '\b': /* ^H (Backspace: '\010') */
         case KEY_BACKSPACE:
+#if 1 /*JP*/
+        moreback:
+#endif
             if (len < 1) {
                 len = 1;
                 mx = promptx;
             }
             p_answer[--len] = '\0';
             mvwaddch(win, my, --mx, ' ');
+#if 1 /*JP*/
+            {
+                int n;
+                n = is_kanji2(p_answer, len);
+                if (n > 0)
+                    goto moreback;
+            }
+#endif
             /* try to unwrap back to the previous line if there is one */
             if (nlines > 1 && (int) strlen(linestarts[nlines - 2]) < width) {
                 mvwaddstr(win, my - 1, border_space, linestarts[nlines - 2]);


### PR DESCRIPTION
### 入力文字削除機能の日本語対応 (win/curses/cursmesg.c)

バックスペースによる入力文字の削除機能の日本語対応です。

現状は 1 バイト単位の削除になっています。

削除前
<img width="600" height="80" alt="jnethack_deletion_1 crop" src="https://github.com/user-attachments/assets/0eefc72f-8e3c-4eed-a54c-20cbd7207139" />
バックスペース 1 回目、1 バイト目削除
<img width="600" height="80" alt="jnethack_deletion_2 crop" src="https://github.com/user-attachments/assets/6fb0a5e5-0c89-46de-8200-4cbe96178db8" />
バックスペース 2 回目、2 バイト目削除
<img width="600" height="80" alt="jnethack_deletion_3 crop" src="https://github.com/user-attachments/assets/baee1f22-4a6e-4d33-a39a-f763f1416fba" />

これを文字単位で削除するように、同様の修正がされた win/tty/getline.c を横目に
実装してみました。

削除前
<img width="600" height="80" alt="jnethack_deletion_fix_1 crop" src="https://github.com/user-attachments/assets/f64c639f-931a-4807-a331-b9cab0ce99e2" />
バックスペース 1 回目、1 文字削除
<img width="600" height="80" alt="jnethack_deletion_fix_2 crop" src="https://github.com/user-attachments/assets/541c8e1b-9380-4bbd-94d9-7ac0eb35c5a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* テキスト入力時のバックスペアキー機能が改善されました。漢字などのマルチバイト文字を削除する際に、複数のバイトからなる文字全体が正しく削除されるようになり、より効率的な入力操作が可能になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->