### PR TITLE
christen_monst() の切り詰め処理を修正

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1338,13 +1338,14 @@ const char *name;
     /* dogname & catname are PL_PSIZ arrays; object names have same limit */
     lth = (name && *name) ? ((int) strlen(name) + 1) : 0;
     if (lth > PL_PSIZ) {
-#if 1 /*JP*/
-        if (is_kanji2(buf, lth - 1))
-            --lth;
-#endif
         lth = PL_PSIZ;
         name = strncpy(buf, name, PL_PSIZ - 1);
+#if 0 /*JP*/
         buf[PL_PSIZ - 1] = '\0';
+#else
+        lth -= offset_in_kanji(buf, lth - 1);
+        buf[lth - 1] = '\0';
+#endif
     }
     new_mname(mtmp, lth); /* removes old name if one is present */
     if (lth)


### PR DESCRIPTION
christen_monst() で扱う文字列がバッファサイズを超える場合の切り詰め処理が間違っていたので修正。
3.6.0のパッチ時点で間違っていたが、フェイルセーフ処理で実際には実行されないので今まで問題になっていなかった。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * プレイヤー名入力時の切り詰め処理を改善しました。漢字・カナなど可変長文字を含む名前で、切り詰め境界における文字の破損や不正な終端が起きにくくなり、表示や保存がより正確になります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jnethack/jnethack-alpha/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->